### PR TITLE
fix: conflicting states for boxes with identical labels (Fixes #4)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -150,12 +150,12 @@ function parseBoxes(text) {
     let match, matchNew, textNew;
 
     while (match = boxOpenRegex.exec(text)) {
+        const boxName = match[1];
         !boxCounters[boxName] ? boxCounters[boxName] = 1 : boxCounters[boxName] += 1
         textNew = text.substring(0, match.index);
 
         matchNew = boxCloseRegex.exec(match[2]);
 
-        const boxName = match[1];
         try {
             const boxContent = matchNew[1];
             textNew += createBox(boxName, boxContent);

--- a/js/index.js
+++ b/js/index.js
@@ -148,13 +148,14 @@ function parseBoxes(text) {
     const boxOpenRegex = /\[box=(.*?)]([\s\S]*)/i;
     const boxCloseRegex = /([\s\S]*?)\[\/box]/i;
     let match, matchNew, textNew;
+
     while (match = boxOpenRegex.exec(text)) {
+        !boxCounters[boxName] ? boxCounters[boxName] = 1 : boxCounters[boxName] += 1
         textNew = text.substring(0, match.index);
 
         matchNew = boxCloseRegex.exec(match[2]);
 
         const boxName = match[1];
-        !boxCounters[boxName] ? boxCounters[boxName] = 1 : boxCounters[boxName] += 1
         try {
             const boxContent = matchNew[1];
             textNew += createBox(boxName, boxContent);

--- a/js/index.js
+++ b/js/index.js
@@ -142,21 +142,22 @@ function errorMessage(message) {
     errorMessageElement.textContent = message;
 }
 
+let boxCounters = {}
+
 function parseBoxes(text) {
     const boxOpenRegex = /\[box=(.*?)]([\s\S]*)/i;
     const boxCloseRegex = /([\s\S]*?)\[\/box]/i;
     let match, matchNew, textNew;
-    let boxCounter = 0
     while (match = boxOpenRegex.exec(text)) {
-        boxCounter++
         textNew = text.substring(0, match.index);
 
         matchNew = boxCloseRegex.exec(match[2]);
 
         const boxName = match[1];
+        !boxCounters[boxName] ? boxCounters[boxName] = 1 : boxCounters[boxName] += 1
         try {
             const boxContent = matchNew[1];
-            textNew += createBox(boxName, boxContent, boxCounter);
+            textNew += createBox(boxName, boxContent);
             textNew += text.substring(match.index + 6 + boxName.length + matchNew[0].length);
 
             text = textNew;
@@ -166,14 +167,14 @@ function parseBoxes(text) {
         }
 
     }
-
+    boxCounters = {}
     return text;
 }
 
-function createBox(name, content, boxCounter){
+function createBox(name, content) {
     content = content.replace(/^<br>/,"");
     content = content.replace(/<br>$/,"");
-    const boxId = `box-${name.substring(0, 9)}${boxCounter}`
+    const boxId = `box-${name.substring(0, 9)}-${boxCounters[name]}`;
     const isOpen = boxStates[boxId] === 'open';
     return `
         <div class="box" onclick="toggleBox('${boxId}', this)">

--- a/js/index.js
+++ b/js/index.js
@@ -146,8 +146,9 @@ function parseBoxes(text) {
     const boxOpenRegex = /\[box=(.*?)]([\s\S]*)/i;
     const boxCloseRegex = /([\s\S]*?)\[\/box]/i;
     let match, matchNew, textNew;
-
+    let boxCounter = 0
     while (match = boxOpenRegex.exec(text)) {
+        boxCounter++
         textNew = text.substring(0, match.index);
 
         matchNew = boxCloseRegex.exec(match[2]);
@@ -155,7 +156,7 @@ function parseBoxes(text) {
         const boxName = match[1];
         try {
             const boxContent = matchNew[1];
-            textNew += createBox(boxName, boxContent);
+            textNew += createBox(boxName, boxContent, boxCounter);
             textNew += text.substring(match.index + 6 + boxName.length + matchNew[0].length);
 
             text = textNew;
@@ -169,10 +170,10 @@ function parseBoxes(text) {
     return text;
 }
 
-function createBox(name, content){
+function createBox(name, content, boxCounter){
     content = content.replace(/^<br>/,"");
     content = content.replace(/<br>$/,"");
-    const boxId = 'box-' + name.substring(0, 9);
+    const boxId = `box-${name.substring(0, 9)}${boxCounter}`
     const isOpen = boxStates[boxId] === 'open';
     return `
         <div class="box" onclick="toggleBox('${boxId}', this)">


### PR DESCRIPTION
Open for further suggestions, feel free to point out any errors I may have missed, and suggest any changes if needed.

Fixes #4 
`Fixes #5` This PR aimed to fix these two issues but this was fixed right after this PR with https://github.com/NoelleTGS/osu-bbcode-editor/commit/d7eb86bfa4761463054fbb8d92e421aa0b5a2f76)

- Each box label gets a unique ID by adding a simple counter at the end of the name.
- Adds `boxCounter` parameter to createBox function.
- Replaces the use of string concatenation with template literals for boxId.
- Update box icon based on open/closed state

Tested with sample BBCode
```bbcode
[box=Example]
This is the content of the box labeled "Example."
[/box]

[box=Example]
This is the content of another box labeled "Example."
[/box]

[box=Example]
This is the content of another box labeled "Example."
[/box]
```
